### PR TITLE
Allow collaborators to consume raw model responses

### DIFF
--- a/src/gui_streamlit.py
+++ b/src/gui_streamlit.py
@@ -13,7 +13,7 @@ st.markdown(
     """
 This demo wraps the core collaboration loop. Provide a task, select a sequence of
 models (comma separated LiteLLM identifiers), and choose how many turns to run.
-Outputs show each critique and the final draft.
+Outputs show each model response and the final draft.
 """
 )
 
@@ -49,10 +49,10 @@ if go:
             except Exception as exc:  # pragma: no cover - interactive surface
                 st.error(f"Failed to run collaboration: {exc}")
             else:
-                with st.expander("Turn-by-turn critiques"):
-                    for idx, (model_name, critique, draft) in enumerate(result.history, start=1):
+                with st.expander("Turn-by-turn responses"):
+                    for idx, (model_name, content) in enumerate(result.history, start=1):
                         st.markdown(f"**Turn {idx} — {model_name}**")
-                        st.markdown(critique)
+                        st.markdown(content)
                 st.subheader("Final Draft")
                 st.code(result.final_draft)
                 if result.convergence:

--- a/src/llm_collaborator/logging_utils.py
+++ b/src/llm_collaborator/logging_utils.py
@@ -27,8 +27,7 @@ def log_iteration(
     *,
     iteration: int,
     model_name: str,
-    critique: str,
-    draft_preview: str,
+    response_preview: str,
     usage: Optional[dict] = None,
 ) -> None:
     """Log an iteration in a structured format."""
@@ -36,8 +35,7 @@ def log_iteration(
     payload: dict[str, Any] = {
         "iteration": iteration,
         "model": model_name,
-        "critique": critique.strip(),
-        "draft_preview": draft_preview.strip()[:200],
+        "response_preview": response_preview.strip()[:200],
     }
     if usage:
         payload["usage"] = usage

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,7 +6,7 @@ def test_build_messages_includes_task_and_draft():
         task="Do something",
         last_draft="Draft text",
         actor_name="Model A",
-        critique_summaries=["Model B: Looks good"],
+        response_summaries=["Model B: Looks good"],
     )
 
     assert messages[0]["role"] == "system"
@@ -14,5 +14,5 @@ def test_build_messages_includes_task_and_draft():
     assert "<task>" in user_message
     assert "Draft text" in user_message
     assert "Model B: Looks good" in user_message
-    assert "<critique>" in user_message
-    assert "<draft>" in user_message
+    assert "<recent_updates>" in user_message
+    assert "updated contribution" in user_message


### PR DESCRIPTION
## Summary
- stop enforcing <critique>/<draft> tags and treat the full model message as the draft
- update prompts, logging, GUI copy, and docs to reflect the new unconstrained response format
- refresh unit tests to assert the new behaviour and keep the collaboration loop context summaries lightweight

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68db4c63b0e4832d9c84f25abd7b7fe3